### PR TITLE
Adding 'connect' and 'disconnecting' events

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,7 +37,7 @@ function initSockets() {
 
         // This event is triggered when the user disconnect but before the socket leave its rooms
         socket.on('disconnecting', function () {
-            for(var room in socket.rooms){
+            for(let room in socket.rooms){
                 // We send a message to all the user of the rooms
                 if(socket.rooms.hasOwnProperty(room) && room != socket.id){
                     io.in(room).emit('user:disconnect', {id: socket.id});

--- a/server.js
+++ b/server.js
@@ -35,10 +35,21 @@ function initSockets() {
             console.log('user disconnected');
         });
 
+        // This event is triggered when the user disconnect but before the socket leave its rooms
+        socket.on('disconnecting', function () {
+            for(var room in socket.rooms){
+                // We send a message to all the user of the rooms
+                if(socket.rooms.hasOwnProperty(room) && room != socket.id){
+                    io.in(room).emit('user:disconnect', {id: socket.id});
+                }
+            }
+        });
+        
         // dynamic room, from https://gist.github.com/crtr0/2896891
         socket.on('app_id', function(app_id) {
             console.log('joining room "'+app_id+'"');
-            // app_id = room
+            // We inform all the other user of the room that a new socket has connected
+            io.sockets.in(app_id).emit('user:connect', {id: socket.id});
             socket.join(app_id);
         });
 

--- a/static/pb2_client.js
+++ b/static/pb2_client.js
@@ -30,6 +30,18 @@ class PB2 {
         receiverFunction(msg);
       }.bind(this));
     }
+    
+    setConnectionHandler(receiverFunction) {
+      this.socket.on('user:connect', function(msg) {
+        receiverFunction(msg);
+      }.bind(this));
+    }
+    
+    setDisconnectionHandler(receiverFunction) {
+      this.socket.on('user:disconnect', function(msg) {
+        receiverFunction(msg);
+      }.bind(this));
+    }
 
     sendJson(json) {
       let msg = {};


### PR DESCRIPTION
The server will now send the event 'user:connect' to all the members of a room when a user will connect and send 'user:disconnect' when one disconnect.

I added a listenner on the server to the event 'disconnecting' which is triggered before the socket leaves all its rooms.
Explanations:

```javascript
// Socket.io file
Socket.prototype.onclose = function(reason){
    if (!this.connected) return this;
    debug('closing socket - reason %s', reason);
    this.emit('disconnecting', reason);  //  <-- Triggering 'disconnecting'
    this.leaveAll();                                 //  <-- Leaving the rooms
    this.nsp.remove(this);
    this.client.remove(this);
    this.connected = false;
    this.disconnected = true;
    delete this.nsp.connected[this.id];
    this.emit('disconnect', reason);      //  <-- Triggering 'disconnect'
};
```

Now on the client side you can add:
```javascript
socket.on('user:disconnect', function (data) {
      console.log("[user:disconnect] User with ID: " + data.id + " has disconnected.")
});

socket.on('user:connect', function (data) {
      console.log("[user:connect] User with ID: " + data.id + " has connected.")
});
```
Or by using the **PB2 Client** :
```javascript
pb2.setConnectionHandler((data) => {
    console.log("[Connect] User with ID: " + data.id + " has connected.")
});

pb2.setDisconnectionHandler((data) => {
    console.log("[Disconnect] User with ID: " + data.id + " has disconnected.")
});
```
